### PR TITLE
fix deprecration warning

### DIFF
--- a/goth/goth.go
+++ b/goth/goth.go
@@ -10,7 +10,7 @@ import (
 // New actions/auth.go file configured to the specified providers.
 func New() (*makr.Generator, error) {
 	g := makr.New()
-	files, err := generators.Find(filepath.Join("github.com", "gobuffalo", "buffalo-goth", "goth"))
+	files, err := generators.FindByBox(filepath.Join("github.com", "gobuffalo", "buffalo-goth", "goth"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
$ buffalo generate goth facebook 
INFO[0000] Find is deprecated, and will be removed in v0.12.0. Use generators.FindByBox instead. Called from /home/rob/gocode/src/github.com/gobuffalo/buffalo-goth/goth/goth.go:13 
      create  actions/auth.go
         run  go get github.com/markbates/goth/...