### PR TITLE
Use the right path for pop package

### DIFF
--- a/auth/templates/actions/auth.go.tmpl
+++ b/auth/templates/actions/auth.go.tmpl
@@ -12,8 +12,8 @@ import (
 	{{range .providers -}}
 	"github.com/markbates/goth/providers/{{ downcase . }}"
   {{end -}}
-	"github.com/markbates/pop"
-	"github.com/markbates/pop/nulls"
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/pop/nulls"
 	"github.com/pkg/errors"
 )
 

--- a/auth/templates/actions/auth_test.go.tmpl
+++ b/auth/templates/actions/auth_test.go.tmpl
@@ -6,7 +6,7 @@ import (
   "{{.packagePath}}/models"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
-	"github.com/markbates/pop/nulls"
+	"github.com/gobuffalo/pop/nulls"
 )
 
 func (as *ActionSuite) Test_AuthCallback_NewUser() {


### PR DESCRIPTION
Since buffalo uses the forked version of pop under gobuffalo,
we should specify the same import path for autogenerated
code from goth, to avoid compilation issues.

This patch should fix #8, tested on my local environment.