### PR TITLE
fix/broken movinglater imports

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gobuffalo/buffalo-goth/genny/auth"
 	"github.com/gobuffalo/genny"
-	"github.com/gobuffalo/genny/movinglater/gotools"
+	"github.com/gobuffalo/genny/gogen"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +36,7 @@ var authCmd = &cobra.Command{
 		}
 		gg.With(r)
 
-		g, err := gotools.GoFmt(r.Root)
+		g, err := gogen.Fmt(r.Root)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gobuffalo/buffalo-goth/genny/goth"
 	"github.com/gobuffalo/genny"
-	"github.com/gobuffalo/genny/movinglater/gotools"
+	"github.com/gobuffalo/genny/gogen"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +36,7 @@ var generateCmd = &cobra.Command{
 		}
 		r.With(g)
 
-		g, err = gotools.GoFmt(r.Root)
+		g, err = gogen.Fmt(r.Root)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/genny/auth/auth.go
+++ b/genny/auth/auth.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gobuffalo/buffalo-goth/genny/goth"
 	"github.com/gobuffalo/genny"
-	"github.com/gobuffalo/genny/movinglater/gotools"
+	"github.com/gobuffalo/genny/gogen"
 	"github.com/gobuffalo/meta"
 	"github.com/gobuffalo/packr"
 	"github.com/pkg/errors"
@@ -38,7 +38,7 @@ func New(opts *Options) (*genny.Group, error) {
 		"providers": opts.Providers,
 		"app":       meta.New("."),
 	}
-	t := gotools.TemplateTransformer(data, h)
+	t := gogen.TemplateTransformer(data, h)
 	g.Transformer(t)
 
 	cmd := exec.Command("buffalo", "db", "generate", "model", "user", "name", "email:nulls.String", "provider", "provider_id")

--- a/genny/goth/goth.go
+++ b/genny/goth/goth.go
@@ -6,8 +6,8 @@ import (
 	"text/template"
 
 	"github.com/gobuffalo/genny"
-	"github.com/gobuffalo/genny/movinglater/gotools"
-	"github.com/gobuffalo/genny/movinglater/gotools/gomods"
+	"github.com/gobuffalo/genny/gogen"
+	"github.com/gobuffalo/gogen/gomods"
 	"github.com/gobuffalo/packr"
 	"github.com/pkg/errors"
 )
@@ -30,7 +30,7 @@ func New(opts *Options) (*genny.Generator, error) {
 	data := map[string]interface{}{
 		"providers": opts.Providers,
 	}
-	t := gotools.TemplateTransformer(data, h)
+	t := gogen.TemplateTransformer(data, h)
 	g.Transformer(t)
 
 	g.RunFn(func(r *genny.Runner) error {
@@ -41,7 +41,7 @@ func New(opts *Options) (*genny.Generator, error) {
 			return errors.WithStack(err)
 		}
 
-		f, err = gotools.AddImport(f, "github.com/markbates/goth/gothic")
+		f, err = gogen.AddImport(f, "github.com/markbates/goth/gothic")
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -51,7 +51,7 @@ func New(opts *Options) (*genny.Generator, error) {
 			"auth.GET(\"/{provider}\", buffalo.WrapHandlerFunc(gothic.BeginAuthHandler))",
 			"auth.GET(\"/{provider}/callback\", AuthCallback)",
 		}
-		f, err = gotools.AddInsideBlock(f, "if app == nil {", expressions...)
+		f, err = gogen.AddInsideBlock(f, "if app == nil {", expressions...)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/genny/goth/goth_test.go
+++ b/genny/goth/goth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/genny"
-	"github.com/gobuffalo/genny/movinglater/gotools/gomods"
+	"github.com/gobuffalo/genny/gogen/gomods"
 	"github.com/stretchr/testify/require"
 )
 

--- a/shoulders.md
+++ b/shoulders.md
@@ -4,72 +4,73 @@ github.com/gobuffalo/buffalo-goth does not try to reinvent the wheel! Instead, i
 
 Thank you to the following **GIANTS**:
 
-- [github.com/BurntSushi/toml](https://godoc.org/github.com/BurntSushi/toml)
 
-- [github.com/gobuffalo/buffalo-goth](https://godoc.org/github.com/gobuffalo/buffalo-goth)
+* [github.com/BurntSushi/toml](https://godoc.org/github.com/BurntSushi/toml)
 
-- [github.com/gobuffalo/buffalo-goth/cmd](https://godoc.org/github.com/gobuffalo/buffalo-goth/cmd)
+* [github.com/gobuffalo/buffalo-goth](https://godoc.org/github.com/gobuffalo/buffalo-goth)
 
-- [github.com/gobuffalo/buffalo-goth/genny/auth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/auth)
+* [github.com/gobuffalo/buffalo-goth/cmd](https://godoc.org/github.com/gobuffalo/buffalo-goth/cmd)
 
-- [github.com/gobuffalo/buffalo-goth/genny/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/goth)
+* [github.com/gobuffalo/buffalo-goth/genny/auth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/auth)
 
-- [github.com/gobuffalo/buffalo-goth/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/goth)
+* [github.com/gobuffalo/buffalo-goth/genny/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/goth)
 
-- [github.com/gobuffalo/buffalo-plugins/plugins](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins)
+* [github.com/gobuffalo/buffalo-goth/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/goth)
 
-- [github.com/gobuffalo/buffalo-plugins/plugins/plugdeps](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins/plugdeps)
+* [github.com/gobuffalo/buffalo-plugins/plugins](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins)
 
-- [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
+* [github.com/gobuffalo/buffalo-plugins/plugins/plugdeps](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins/plugdeps)
 
-- [github.com/gobuffalo/events](https://godoc.org/github.com/gobuffalo/events)
+* [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
 
-- [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
+* [github.com/gobuffalo/events](https://godoc.org/github.com/gobuffalo/events)
 
-- [github.com/gobuffalo/flect/name](https://godoc.org/github.com/gobuffalo/flect/name)
+* [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
 
-- [github.com/gobuffalo/genny](https://godoc.org/github.com/gobuffalo/genny)
+* [github.com/gobuffalo/flect/name](https://godoc.org/github.com/gobuffalo/flect/name)
 
-- [github.com/gobuffalo/genny/gogen](https://godoc.org/github.com/gobuffalo/genny/gogen)
+* [github.com/gobuffalo/genny](https://godoc.org/github.com/gobuffalo/genny)
 
-- [github.com/gobuffalo/genny/gogen/goimports](https://godoc.org/github.com/gobuffalo/genny/gogen/goimports)
+* [github.com/gobuffalo/genny/gogen](https://godoc.org/github.com/gobuffalo/genny/gogen)
 
-- [github.com/gobuffalo/genny/gogen/gomods](https://godoc.org/github.com/gobuffalo/genny/gogen/gomods)
+* [github.com/gobuffalo/genny/gogen/goimports](https://godoc.org/github.com/gobuffalo/genny/gogen/goimports)
 
-- [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
+* [github.com/gobuffalo/genny/gogen/gomods](https://godoc.org/github.com/gobuffalo/genny/gogen/gomods)
 
-- [github.com/gobuffalo/mapi](https://godoc.org/github.com/gobuffalo/mapi)
+* [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
 
-- [github.com/gobuffalo/meta](https://godoc.org/github.com/gobuffalo/meta)
+* [github.com/gobuffalo/mapi](https://godoc.org/github.com/gobuffalo/mapi)
 
-- [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
+* [github.com/gobuffalo/meta](https://godoc.org/github.com/gobuffalo/meta)
 
-- [github.com/gobuffalo/packr](https://godoc.org/github.com/gobuffalo/packr)
+* [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
 
-- [github.com/joho/godotenv](https://godoc.org/github.com/joho/godotenv)
+* [github.com/gobuffalo/packr](https://godoc.org/github.com/gobuffalo/packr)
 
-- [github.com/karrick/godirwalk](https://godoc.org/github.com/karrick/godirwalk)
+* [github.com/joho/godotenv](https://godoc.org/github.com/joho/godotenv)
 
-- [github.com/markbates/oncer](https://godoc.org/github.com/markbates/oncer)
+* [github.com/karrick/godirwalk](https://godoc.org/github.com/karrick/godirwalk)
 
-- [github.com/markbates/safe](https://godoc.org/github.com/markbates/safe)
+* [github.com/markbates/oncer](https://godoc.org/github.com/markbates/oncer)
 
-- [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
+* [github.com/markbates/safe](https://godoc.org/github.com/markbates/safe)
 
-- [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
+* [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
 
-- [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
+* [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
 
-- [github.com/spf13/pflag](https://godoc.org/github.com/spf13/pflag)
+* [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
 
-- [golang.org/x/crypto/ssh/terminal](https://godoc.org/golang.org/x/crypto/ssh/terminal)
+* [github.com/spf13/pflag](https://godoc.org/github.com/spf13/pflag)
 
-- [golang.org/x/sys/unix](https://godoc.org/golang.org/x/sys/unix)
+* [golang.org/x/crypto/ssh/terminal](https://godoc.org/golang.org/x/crypto/ssh/terminal)
 
-- [golang.org/x/tools/go/ast/astutil](https://godoc.org/golang.org/x/tools/go/ast/astutil)
+* [golang.org/x/sys/unix](https://godoc.org/golang.org/x/sys/unix)
 
-- [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports)
+* [golang.org/x/tools/go/ast/astutil](https://godoc.org/golang.org/x/tools/go/ast/astutil)
 
-- [golang.org/x/tools/internal/fastwalk](https://godoc.org/golang.org/x/tools/internal/fastwalk)
+* [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports)
 
-- [golang.org/x/tools/internal/gopathwalk](https://godoc.org/golang.org/x/tools/internal/gopathwalk)
+* [golang.org/x/tools/internal/fastwalk](https://godoc.org/golang.org/x/tools/internal/fastwalk)
+
+* [golang.org/x/tools/internal/gopathwalk](https://godoc.org/golang.org/x/tools/internal/gopathwalk)

--- a/shoulders.md
+++ b/shoulders.md
@@ -4,73 +4,72 @@ github.com/gobuffalo/buffalo-goth does not try to reinvent the wheel! Instead, i
 
 Thank you to the following **GIANTS**:
 
+- [github.com/BurntSushi/toml](https://godoc.org/github.com/BurntSushi/toml)
 
-* [github.com/BurntSushi/toml](https://godoc.org/github.com/BurntSushi/toml)
+- [github.com/gobuffalo/buffalo-goth](https://godoc.org/github.com/gobuffalo/buffalo-goth)
 
-* [github.com/gobuffalo/buffalo-goth](https://godoc.org/github.com/gobuffalo/buffalo-goth)
+- [github.com/gobuffalo/buffalo-goth/cmd](https://godoc.org/github.com/gobuffalo/buffalo-goth/cmd)
 
-* [github.com/gobuffalo/buffalo-goth/cmd](https://godoc.org/github.com/gobuffalo/buffalo-goth/cmd)
+- [github.com/gobuffalo/buffalo-goth/genny/auth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/auth)
 
-* [github.com/gobuffalo/buffalo-goth/genny/auth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/auth)
+- [github.com/gobuffalo/buffalo-goth/genny/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/goth)
 
-* [github.com/gobuffalo/buffalo-goth/genny/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/genny/goth)
+- [github.com/gobuffalo/buffalo-goth/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/goth)
 
-* [github.com/gobuffalo/buffalo-goth/goth](https://godoc.org/github.com/gobuffalo/buffalo-goth/goth)
+- [github.com/gobuffalo/buffalo-plugins/plugins](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins)
 
-* [github.com/gobuffalo/buffalo-plugins/plugins](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins)
+- [github.com/gobuffalo/buffalo-plugins/plugins/plugdeps](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins/plugdeps)
 
-* [github.com/gobuffalo/buffalo-plugins/plugins/plugdeps](https://godoc.org/github.com/gobuffalo/buffalo-plugins/plugins/plugdeps)
+- [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
 
-* [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
+- [github.com/gobuffalo/events](https://godoc.org/github.com/gobuffalo/events)
 
-* [github.com/gobuffalo/events](https://godoc.org/github.com/gobuffalo/events)
+- [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
 
-* [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
+- [github.com/gobuffalo/flect/name](https://godoc.org/github.com/gobuffalo/flect/name)
 
-* [github.com/gobuffalo/flect/name](https://godoc.org/github.com/gobuffalo/flect/name)
+- [github.com/gobuffalo/genny](https://godoc.org/github.com/gobuffalo/genny)
 
-* [github.com/gobuffalo/genny](https://godoc.org/github.com/gobuffalo/genny)
+- [github.com/gobuffalo/genny/gogen](https://godoc.org/github.com/gobuffalo/genny/gogen)
 
-* [github.com/gobuffalo/genny/movinglater/gotools](https://godoc.org/github.com/gobuffalo/genny/movinglater/gotools)
+- [github.com/gobuffalo/genny/gogen/goimports](https://godoc.org/github.com/gobuffalo/genny/gogen/goimports)
 
-* [github.com/gobuffalo/genny/movinglater/gotools/goimports](https://godoc.org/github.com/gobuffalo/genny/movinglater/gotools/goimports)
+- [github.com/gobuffalo/genny/gogen/gomods](https://godoc.org/github.com/gobuffalo/genny/gogen/gomods)
 
-* [github.com/gobuffalo/genny/movinglater/gotools/gomods](https://godoc.org/github.com/gobuffalo/genny/movinglater/gotools/gomods)
+- [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
 
-* [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
+- [github.com/gobuffalo/mapi](https://godoc.org/github.com/gobuffalo/mapi)
 
-* [github.com/gobuffalo/mapi](https://godoc.org/github.com/gobuffalo/mapi)
+- [github.com/gobuffalo/meta](https://godoc.org/github.com/gobuffalo/meta)
 
-* [github.com/gobuffalo/meta](https://godoc.org/github.com/gobuffalo/meta)
+- [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
 
-* [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
+- [github.com/gobuffalo/packr](https://godoc.org/github.com/gobuffalo/packr)
 
-* [github.com/gobuffalo/packr](https://godoc.org/github.com/gobuffalo/packr)
+- [github.com/joho/godotenv](https://godoc.org/github.com/joho/godotenv)
 
-* [github.com/joho/godotenv](https://godoc.org/github.com/joho/godotenv)
+- [github.com/karrick/godirwalk](https://godoc.org/github.com/karrick/godirwalk)
 
-* [github.com/karrick/godirwalk](https://godoc.org/github.com/karrick/godirwalk)
+- [github.com/markbates/oncer](https://godoc.org/github.com/markbates/oncer)
 
-* [github.com/markbates/oncer](https://godoc.org/github.com/markbates/oncer)
+- [github.com/markbates/safe](https://godoc.org/github.com/markbates/safe)
 
-* [github.com/markbates/safe](https://godoc.org/github.com/markbates/safe)
+- [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
 
-* [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
+- [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
 
-* [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
+- [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
 
-* [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
+- [github.com/spf13/pflag](https://godoc.org/github.com/spf13/pflag)
 
-* [github.com/spf13/pflag](https://godoc.org/github.com/spf13/pflag)
+- [golang.org/x/crypto/ssh/terminal](https://godoc.org/golang.org/x/crypto/ssh/terminal)
 
-* [golang.org/x/crypto/ssh/terminal](https://godoc.org/golang.org/x/crypto/ssh/terminal)
+- [golang.org/x/sys/unix](https://godoc.org/golang.org/x/sys/unix)
 
-* [golang.org/x/sys/unix](https://godoc.org/golang.org/x/sys/unix)
+- [golang.org/x/tools/go/ast/astutil](https://godoc.org/golang.org/x/tools/go/ast/astutil)
 
-* [golang.org/x/tools/go/ast/astutil](https://godoc.org/golang.org/x/tools/go/ast/astutil)
+- [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports)
 
-* [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports)
+- [golang.org/x/tools/internal/fastwalk](https://godoc.org/golang.org/x/tools/internal/fastwalk)
 
-* [golang.org/x/tools/internal/fastwalk](https://godoc.org/golang.org/x/tools/internal/fastwalk)
-
-* [golang.org/x/tools/internal/gopathwalk](https://godoc.org/golang.org/x/tools/internal/gopathwalk)
+- [golang.org/x/tools/internal/gopathwalk](https://godoc.org/golang.org/x/tools/internal/gopathwalk)


### PR DESCRIPTION
I couldn't install `buffalo-goth`, and this seemed to fix it.