### PR TITLE
Add missing plugins install step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ In Buffalo `v0.9.4` the built in generator for [github.com/markbates/goth](https
 
 ```bash
 $ go get -u github.com/gobuffalo/buffalo-goth
+$ buffalo plugins install github.com/gobuffalo/buffalo-goth
 ```
 
 ## Usage


### PR DESCRIPTION
This step was missing, and it left me puzzled [this](https://gobuffalo.io/en/docs/goth/) page doesn't mention it as a requirement either.

@markbates 