### PR TITLE
Enforce box name to ensure correct template are used.

### DIFF
--- a/genny/auth/auth.go
+++ b/genny/auth/auth.go
@@ -26,7 +26,7 @@ func New(opts *Options) (*genny.Group, error) {
 
 	g = genny.New()
 
-	if err := g.Box(packr.New("", "../auth/templates")); err != nil {
+	if err := g.Box(packr.New("../auth/templates", "../auth/templates")); err != nil {
 		return gg, errors.WithStack(err)
 	}
 

--- a/genny/goth/goth.go
+++ b/genny/goth/goth.go
@@ -17,7 +17,7 @@ func New(opts *Options) (*genny.Generator, error) {
 		return g, errors.New("you must specify at least one provider")
 	}
 
-	if err := g.Box(packr.New("", "../goth/templates")); err != nil {
+	if err := g.Box(packr.New("../goth/templates", "../goth/templates")); err != nil {
 		return g, errors.WithStack(err)
 	}
 


### PR DESCRIPTION
Use name to ensure correct template are used.
This should fix #37 and #34